### PR TITLE
Bump `Dictionaries` compat to v0.4

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ Dictionaries = "85a47980-9c8c-11e8-2b9f-f7ca1fa99fb4"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
-Dictionaries = "0.2, 0.3"
+Dictionaries = "0.2, 0.3, 0.4"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
`Dictionaries` v0.4 changed the copying behavior of dictionaries to copy both the keys and values (before it only copied the values), see https://github.com/andyferris/Dictionaries.jl/pull/136.